### PR TITLE
Further improvements to page reload fix

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -32,7 +32,8 @@ module.exports = {
       },
       rules: {
         'linebreak-style': 0,
-        'vuejs-accessibility/click-events-have-key-events': 'off'
+        'vuejs-accessibility/click-events-have-key-events': 'off',
+        'no-param-reassign': ['error',{ props: false }],
       }
     }
   ],

--- a/src/entry/aws-console.ts
+++ b/src/entry/aws-console.ts
@@ -161,37 +161,31 @@ function customizeConsole(aws: AwsConsole): void {
   let footerLblPromise;
   if (aws.user!.custom.colorHeader) {
     getHeader().then((header) => {
-      // eslint-disable-next-line no-param-reassign
       header.style.backgroundColor = `#${color || '222f3e'}`;
     });
     headerLblPromise = getHeaderLabel(aws.userType);
     headerLblPromise.then((headerLbl) => {
-      // eslint-disable-next-line no-param-reassign
       headerLbl.style.color = getFontColor(color);
     });
   }
   if (aws.user!.custom.colorFooter) {
     getFooter().then((footer) => {
-      // eslint-disable-next-line no-param-reassign
       footer.style.backgroundColor = `#${color || '222f3e'}`;
     });
     footerLblPromise = getFooterLabel();
     footerLblPromise.then((footerLbl) => {
-      // eslint-disable-next-line no-param-reassign
       footerLbl.style.color = getFontColor(color);
     });
   }
   if (aws.user!.custom.labelFooter) {
     footerLblPromise ??= getFooterLabel();
     footerLblPromise.then((footerLbl) => {
-      // eslint-disable-next-line no-param-reassign
       footerLbl.textContent = label || defaultFooter;
     });
   }
   // iam user has header already applied
   if (aws.user!.custom.labelHeader) {
     getHeaderLabel(aws.userType).then((headerLbl) => {
-      // eslint-disable-next-line no-param-reassign
       headerLbl.textContent = label || defaultHeader;
     });
   }


### PR DESCRIPTION
Further fix #15 
- Faster apply of the customizations by doing it as soon as it available. e.g. footer seems take longer load than the header (at least on my tests)
- Use a more stable css selector for footer
- I've optionally tweaked the 'no-param-reassign' as a suggestion