### PR TITLE
fix console customization only works on start page

### DIFF
--- a/src/entry/aws-console.ts
+++ b/src/entry/aws-console.ts
@@ -231,7 +231,7 @@ async function init(): Promise<AwsConsole> {
   return aws;
 }
 
-if (window.location.href.includes('console.aws.amazon.com/console/home')) {
+if (window.location.href.includes('console.aws.amazon.com/')) {
   // get console info
   init().then((aws) => {
     extension.log(aws);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -27,7 +27,7 @@
     },
     {
       "matches": [
-        "https://*.console.aws.amazon.com/console/home?region*"
+        "https://*.console.aws.amazon.com/*"
       ],
       "js": [
         "src/entry/aws-console.ts"


### PR DESCRIPTION
When you navigate to other services it loses the customization, this PR fixes it by broadening the urls where the extension runs.