### PR TITLE
Release 1.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.8.5
+- Fix container expiration to be in minutes, not milliseconds
+
 ## 1.8.4
 - Added setting to expire firefox containers after X minutes, ideally set to your session duration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-sso-extender",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-sso-extender",
-      "version": "1.8.4",
+      "version": "1.8.5",
       "dependencies": {
         "async-sema": "^3.1.1",
         "clipboard": "^2.0.11",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "WTFender",
   "url": "https://github.com/WTFender/aws-sso-extender",
   "private": true,
-  "version": "1.8.4",
+  "version": "1.8.5",
   "type": "module",
   "scripts": {
     "prepare": "husky install",

--- a/src/entry/background.ts
+++ b/src/entry/background.ts
@@ -80,7 +80,7 @@ extension.loadData().then((data: ExtensionData) => {
             setTimeout(() => { 
               extension.log('background:expireFirefoxContainer');
               extension.config.browser.contextualIdentities.remove(msg.cookieStoreId!);
-            }, data.settings.firefoxExpireMinsContainer);
+            }, (data.settings.firefoxExpireMinsContainer * 60 * 1000));
           }
         });
       },


### PR DESCRIPTION
- Fix container expiration to be in minutes, not milliseconds
