### PR TITLE
Add Copy Signin Link Button

### DIFF
--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -243,6 +243,7 @@ const demoData: ExtensionData = {
   settings: {
     defaultUser: 'lastUserId',
     enableSync: false,
+    copyLinkButton: true,
     lastUserId: users[0].userId,
     lastProfileId: 'p-124',
     firefoxContainers: true,

--- a/src/entry/aws-console.ts
+++ b/src/entry/aws-console.ts
@@ -176,7 +176,7 @@ function customizeConsole(aws: AwsConsole): void {
           // if it's a button we'll change the id to be unique from the label button
           if (copiedNode.nodeName=="BUTTON") copiedNode.id="copyLinkButton"
           // Append the element as a child for each time we go through the loop after the first.  The childmost element will have its text updated
-          if (priorNode) {copiedNode.appendChild(priorNode)} else {copiedNode.textContent="Copy Link"; copiedNode.title="Copy direct signin link"}
+          if (priorNode) {copiedNode.appendChild(priorNode)} else {copiedNode.textContent="Copy Link"; copiedNode.title="Copy link to current AWS console page"}
           priorNode=copiedNode
           parentElement=parentElement.parentElement
         }

--- a/src/entry/aws-console.ts
+++ b/src/entry/aws-console.ts
@@ -161,6 +161,43 @@ function customizeConsole(aws: AwsConsole): void {
       headerLbl.textContent = `${aws.user?.custom.labelIcon && aws.appProfile?.profile.custom?.icon ? aws.appProfile?.profile.custom?.icon : ''} ${label || defaultHeader}`;
     });
   }
+
+  if (aws.data?.settings.copyLinkButton){
+    // make a copy link button
+    waitForElement("#awsc-navigation__more-menu--list").then((menuList) => {
+      getHeaderLabel(aws.userType).then((headerLbl) => {
+        var parentElement:HTMLElement|null = headerLbl;
+        var priorNode: HTMLElement|null=null;
+        var copiedNode:HTMLElement|null=null;
+        // find the li element which is parent of the header label button, shallow clone so we can create a new element with matching style, but not create the other child elements
+        while ( parentElement && (priorNode==null || priorNode.nodeName!="LI") )
+        {
+          copiedNode=<HTMLElement>parentElement.cloneNode()
+          // if it's a button we'll change the id to be unique from the label button
+          if (copiedNode.nodeName=="BUTTON") copiedNode.id="copyLinkButton"
+          // Append the element as a child for each time we go through the loop after the first.  The childmost element will have its text updated
+          if (priorNode) {copiedNode.appendChild(priorNode)} else {copiedNode.textContent="Copy Link"; copiedNode.title="Copy direct signin link"}
+          priorNode=copiedNode
+          parentElement=parentElement.parentElement
+        }
+        // add the new node we made in the above loop to the nav bar
+        if (copiedNode) menuList.append(copiedNode);
+        // run the function below when the button is clicked
+        document.getElementById("copyLinkButton")?.addEventListener("click", () => copyToClipBoard(aws.user!.managedActiveDirectoryId,aws.accountId!,aws.ssoRoleName!))
+      });
+    });
+  }
+}
+
+
+function copyToClipBoard(awsDirectoryId: string,accountId: string,ssoRoleName: string){
+  var linkurl="https://"+awsDirectoryId+".awsapps.com/start/#/console?account_id="+accountId+"&role_name="+ssoRoleName+"&destination="+encodeURIComponent(window.location.href);
+  navigator.clipboard.writeText(linkurl);
+  waitForElement('#copyLinkButton').then(async (el)=> { var textElement=el.querySelector("span"); if (textElement){textElement.textContent="Link Copied"; await delay(1000); textElement.textContent="Copy Link"}})
+}
+
+function delay(ms: number) {
+  return new Promise( resolve => setTimeout(resolve, ms) );
 }
 
 async function init(): Promise<AwsConsole> {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -22,6 +22,7 @@ export interface ExtensionConfig {
 export interface ExtensionSettings {
   defaultUser: string;
   enableSync: boolean;
+  copyLinkButton: boolean;
   lastUserId: string;
   lastProfileId: string;
   firefoxContainers?: boolean;

--- a/src/views/options.vue
+++ b/src/views/options.vue
@@ -347,6 +347,20 @@
                   Workaround is to render our own dialog box on firefox with the elements
                 -->
             <PCheckbox
+              v-model="settings.copyLinkButton"
+              v-tooltip.bottom="'Show button to copy a shareable link to the current AWS account, role, & console page (default: true)'"
+              input-id="copyLink"
+              class="option-value setting-checkbox"
+              name="copyLink"
+              :binary="true"
+              style="margin-right: 10px; text-align: middle"
+              @click="settings.copyLinkButton = !settings.copyLinkButton;"
+            />
+            <label
+              for="copyLink"
+              style="font-size: 1rem; vertical-align: middle;"
+            >Show Copy Link Button</label><br>
+            <PCheckbox
               v-if="$ext.platform === 'firefox'"
               v-model="settings.firefoxContainers"
               v-tooltip.bottom="'Open the AWS Console in Firefox Containers'"
@@ -355,11 +369,12 @@
               name="container"
               :binary="true"
               style="margin-right: 10px; text-align: middle"
-              @click="toggleContainers()"
+              @click="settings.firefoxContainers = !settings.firefoxContainers;"
             />
             <label
               v-if="$ext.platform === 'firefox'"
               for="container"
+              style="font-size: 1rem; vertical-align: middle;"
             >Open in Firefox Containers</label><br>
             <PCheckbox
               v-if="$ext.platform === 'firefox' && settings.firefoxContainers"
@@ -367,7 +382,6 @@
               v-tooltip.bottom="'Open existing firefox containers; disable to spawn a new container each time.'"
               input-id="resumeContainer"
               class="option-value setting-checkbox"
-              name="resumeContainer"
               :binary="true"
               style="margin-right: 10px; text-align: middle"
             />
@@ -541,7 +555,6 @@ export default {
         { label: 'Show All Profiles on Open', id: 'showAllProfiles', tooltip: 'Show all profiles when opening the extension popup, instead of filtering to favorites (default: false)' },
         { label: 'Show Release Notes on Update', id: 'showReleaseNotes', tooltip: 'When the extension is updated, open a browser tab with a link to the release notes (default: true)' },
         { label: 'Sync User Settings', id: 'enableSync', tooltip: 'Sync user settings across browsers. (default: true)' },
-        { label: 'Show Copy Link Button', id: 'copyLinkButton', tooltip: 'Display a button that copies a signin link for the current console URL, including the account and profile. (default: true)' },
       ],
       resources: [
         {
@@ -786,9 +799,6 @@ export default {
         type: 'application/json',
       });
       saveAs(fileToSave, `${this.user.custom.displayName || this.user.subject}-${this.$ext.config.name}.json`);
-    },
-    toggleContainers() {
-      this.settings.firefoxContainers = !this.settings.firefoxContainers;
     },
     requestPermissionsContainers() {
       this.$ext.config.browser.permissions.request({

--- a/src/views/options.vue
+++ b/src/views/options.vue
@@ -541,6 +541,7 @@ export default {
         { label: 'Show All Profiles on Open', id: 'showAllProfiles', tooltip: 'Show all profiles when opening the extension popup, instead of filtering to favorites (default: false)' },
         { label: 'Show Release Notes on Update', id: 'showReleaseNotes', tooltip: 'When the extension is updated, open a browser tab with a link to the release notes (default: true)' },
         { label: 'Sync User Settings', id: 'enableSync', tooltip: 'Sync user settings across browsers. (default: true)' },
+        { label: 'Show Copy Link Button', id: 'copyLinkButton', tooltip: 'Display a button that copies a signin link for the current console URL, including the account and profile. (default: true)' },
       ],
       resources: [
         {


### PR DESCRIPTION
Use new shortcuts feature to allow a one-click copy link button for the current page that can be saved or shared.  Very useful to share links with colleagues in an environment with many accounts.

https://docs.aws.amazon.com/singlesignon/latest/userguide/createshortcutlink.html?icmpid=docs_sso_console&ck_subscriber_id=908327837