### PR TITLE
Keep the URL of the currently open tab when switching accounts

### DIFF
--- a/src/components/ProfileTable.vue
+++ b/src/components/ProfileTable.vue
@@ -557,7 +557,7 @@ export default {
     awsAccountNameLabel() {
       // accountName
       let label = this.activeProfile.searchMetadata!.AccountName
-      // accountName (label) 
+      // accountName (label)
       if (this.activeProfile.searchMetadata!.AccountId in this.user.custom.accounts) {
         label += ` (${this.user.custom.accounts[this.activeProfile.searchMetadata!.AccountId].label})`
       }
@@ -619,7 +619,7 @@ export default {
         });
       }
       if (this.newTableSettings.sortProfile === 'desc') {
-        return profiles.sort((a, b) => { 
+        return profiles.sort((a, b) => {
           const sortA = a.profile.custom?.label || a.profile.name;
           const sortB = b.profile.custom?.label || b.profile.name;
           return sortA.localeCompare(sortB);
@@ -888,12 +888,13 @@ export default {
           if (this.settings.showAllProfiles && !this.user.appProfileIds.includes(appProfile.profile.id)) {
             user = this.$ext.findUserByProfileId(appProfile.profile.id, this.users);
           }
-          const profileUrl = this.$ext.createProfileUrl(user, appProfile);
-          if (this.settings.navCurrentTab) {
-            this.$ext.navCurrentTab(profileUrl);
-          } else {
-            window.open(profileUrl, '_blank');
-          }
+          this.$ext.createProfileUrl(user, appProfile).then((profileUrl) => {
+            if (this.settings.navCurrentTab) {
+              this.$ext.navCurrentTab(profileUrl);
+            } else {
+              window.open(profileUrl, '_blank');
+            }
+          });
         });
       });
     },

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -320,17 +320,24 @@ class Extension {
     return data;
   }
 
-  createProfileUrl(user: UserData, appProfile: AppData) {
-    this.log('createProfileUrl');
+  async createProfileUrl(user: UserData, appProfile: AppData): Promise<string> {
+    console.log('createProfileUrl');
     const ssoDirUrl = `https://${user.managedActiveDirectoryId}.awsapps.com/start/#/saml`;
     const appProfileName = encodeUriPlusParens(appProfile.name);
+
     if (appProfile.profile.name === 'Default') {
       return `${ssoDirUrl}/default/${appProfileName}/${appProfile.id}`;
     }
-    const appProfilePath = encodeUriPlusParens(
-      btoa(`${user.accountId}_${appProfile.id}_${appProfile.profile.id}`),
-    );
-    return `${ssoDirUrl}/custom/${appProfileName}/${appProfilePath}`;
+
+    let consoleUrl = `https://${user.managedActiveDirectoryId}.awsapps.com/start/#/console?account_id=${appProfile.searchMetadata?.AccountId}&role_name=${appProfile.profile.name}`;
+
+    const currentTab = (await this.config.browser.tabs.query({currentWindow: true, active: true}))[0];
+    // if the current tab in the console, specify the destination
+    if (currentTab.url?.match(this.consoleUrlRegex)) {
+      consoleUrl = `${consoleUrl}&destination=${encodeURIComponent(currentTab.url)}`;
+    }
+
+    return consoleUrl;
   }
 
   parseAppProfiles(): AppData[] {
@@ -429,7 +436,7 @@ class Extension {
       if (profile.applicationName === 'AWS Account') {
         if (profile.searchMetadata?.AccountId! in user.custom.accounts) {
           if (user.custom.accountsOverride || profile.profile.custom.color === user.custom.colorDefault) {
-            profile.profile.custom = { 
+            profile.profile.custom = {
               ...profile.profile.custom,
               color: user.custom.accounts[ap.searchMetadata?.AccountId!].color,
             };
@@ -564,7 +571,7 @@ class Extension {
       user = this.findUserByProfileId(profile.profile.id, users);
     }
     this.log(profile);
-    const profileUrl = this.createProfileUrl(user, profile);
+    const profileUrl = await this.createProfileUrl(user, profile);
     if (this.platform === 'firefox' && settings.firefoxContainers) {
       let containers: ContextualIdentity[] = [];
       // query existing containers

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -90,15 +90,18 @@
     "value": "same-origin"
   },
   "{{safari}}.permissions": [
-    "storage"
+    "storage",
+    "tabs"
   ],
   "{{chrome}}.permissions": [
-    "storage"
+    "storage",
+    "tabs"
   ],
   "{{firefox}}.permissions": [
     "contextualIdentities",
     "cookies",
-    "storage"
+    "storage",
+    "tabs"
   ],
   "{{chrome}}.optional_permissions": [
     "history"
@@ -106,7 +109,6 @@
   "{{firefox}}.optional_permissions": [
     "activeTab",
     "history",
-    "tabs",
     "webRequest",
     "webRequestBlocking",
     "webRequestFilterResponse",


### PR DESCRIPTION
Current behavior is to always go to home when switching accounts.

After using this extension for a few days, I often felt that I wanted to open the same page of other accounts when using many accounts.

I suggest changing the behavior to retain the URL of the currently open tab when switching accounts.

(Related to another developer's suggestion in #141 to add default region and default page as options for this extension.)

The original implementation had a transition to `${ssoDirUrl}/custom/${appProfileName}/${appProfilePath};`, but I am not sure if I should remove this, please advise.

https://github.com/user-attachments/assets/3407c0f8-3275-4f89-a232-5e947da34a26

