### PR TITLE
feat: manage aws multi session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.10.0
+- Manage [AWS Console multi-session feature](https://aws.amazon.com/fr/about-aws/whats-new/2025/01/aws-management-console-simultaneous-sign-in-multiple-accounts/)
+
 ## 1.9.4
 - Switching profiles will now retain the focused profile's region & page (thanks @j-smz)
 - Fixed console labels not displaying due to AWS console changes (thanks @chrisgilbert)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "WTFender",
   "url": "https://github.com/WTFender/aws-sso-extender",
   "private": true,
-  "version": "1.9.4",
+  "version": "1.10.0",
   "type": "module",
   "scripts": {
     "prepare": "husky install",

--- a/src/entry/aws-console.ts
+++ b/src/entry/aws-console.ts
@@ -107,9 +107,10 @@ function checkIamLogins(aws: AwsConsole) {
   }
 }
 
-function getMenu() {
-  return waitForElement('#menu--account');
+function getAccountMenu() {
+  return waitForElement('[data-testid="account-detail-menu"]')
 }
+
 function getHeader() {
   return waitForElement('#awsc-top-level-nav');
 }
@@ -206,6 +207,41 @@ function delay(ms: number) {
   return new Promise( resolve => setTimeout(resolve, ms) );
 }
 
+const accountMenuHasOneOfAccountPrompts = (accountMenu: HTMLElement, prompts: string[]): boolean => {
+  const allDivs = Array.from(accountMenu.querySelectorAll('div'));
+  
+  return allDivs.some(div => {
+    const text = div.textContent?.trim() ?? '';
+    return prompts.includes(text);
+  });
+};
+
+const parseSsoMenu = (accountMenu: HTMLElement, prompts: string[]): {
+  accountId: string | null;
+  roleName: string | null;
+  ssoRoleName: string | null;
+} => {
+  const accountIdDiv = Array.from(accountMenu.querySelectorAll('div')).find(div => {
+    const text = div.textContent?.trim() ?? '';
+      return prompts.includes(text)
+  });
+  
+  let accountId: string|null = null;
+    if (accountIdDiv) {
+      const accountIdSpan = accountIdDiv.parentElement?.querySelector('div > span:last-of-type');
+
+    if (accountIdSpan) {
+      accountId = accountIdSpan.textContent?.replaceAll('-', '') || null;
+    }
+  }
+
+  const roleNameDiv = accountMenu.querySelector('div[title]');
+  const roleName = roleNameDiv?.getAttribute('title') || null;  
+  const ssoRole = roleName ? ssoRoleName(roleName) : null;
+
+  return { accountId, roleName, ssoRoleName: ssoRole };
+}
+
 async function init(): Promise<AwsConsole> {
   const aws: AwsConsole = {
     userType: null,
@@ -224,13 +260,8 @@ async function init(): Promise<AwsConsole> {
   // old sso: 'Account ID: '
   // new iam: 'Currently active as'
   // new sso: 'Account ID'
-  const menu = await getMenu();
-  const accountMenu = menu.firstElementChild!.firstElementChild!;
-  const oldAccountPrompt = accountMenu.firstElementChild!.getElementsByTagName('span')[0].textContent || '';
-  let accountPrompt = '';
-  if (oldAccountPrompt === '') {
-    accountPrompt = accountMenu!.firstElementChild!.firstElementChild!.firstElementChild!.firstElementChild!.textContent!;
-  }
+  const accountMenu = await getAccountMenu();
+  const oldAccountPrompt = accountMenu!.firstElementChild!.getElementsByTagName('span')[0].textContent || '';
   if (oldAccountPrompt === 'Currently active as: ') {
     aws.userType = 'iam';
     aws.accountId = accountMenu!.lastElementChild!.getElementsByTagName('span')[1].textContent!.replaceAll('-', '');
@@ -240,12 +271,10 @@ async function init(): Promise<AwsConsole> {
     aws.accountId = accountMenu!.firstElementChild!.getElementsByTagName('span')[1].textContent!.replaceAll('-', '');
     aws.roleName = accountMenu!.lastElementChild!.getAttribute('title')!;
     aws.ssoRoleName = ssoRoleName(aws.roleName);
-  } else if (ssoAccountPrompts.includes(accountPrompt)) {
+  } else if (accountMenuHasOneOfAccountPrompts(accountMenu, ssoAccountPrompts)) {
     extension.log('sso user');
     aws.userType = 'sso';
-    aws.accountId = accountMenu!.firstElementChild!.getElementsByTagName('span')[3].textContent!.replaceAll('-', '');
-    aws.roleName = accountMenu!.firstElementChild!.lastElementChild?.firstElementChild!.getAttribute('title')!;
-    aws.ssoRoleName = ssoRoleName(aws.roleName);
+    Object.assign(aws, parseSsoMenu(accountMenu, ssoAccountPrompts));
   } else {
     extension.log('iam user');
     aws.userType = 'iam';

--- a/src/entry/aws-console.ts
+++ b/src/entry/aws-console.ts
@@ -207,40 +207,67 @@ function delay(ms: number) {
   return new Promise( resolve => setTimeout(resolve, ms) );
 }
 
-const accountMenuHasOneOfAccountPrompts = (accountMenu: HTMLElement, prompts: string[]): boolean => {
-  const allDivs = Array.from(accountMenu.querySelectorAll('div'));
-  
-  return allDivs.some(div => {
-    const text = div.textContent?.trim() ?? '';
-    return prompts.includes(text);
-  });
-};
-
-const parseSsoMenu = (accountMenu: HTMLElement, prompts: string[]): {
+interface AccountMenuInfo {
   accountId: string | null;
   roleName: string | null;
   ssoRoleName: string | null;
-} => {
-  const accountIdDiv = Array.from(accountMenu.querySelectorAll('div')).find(div => {
-    const text = div.textContent?.trim() ?? '';
-      return prompts.includes(text)
-  });
-  
-  let accountId: string|null = null;
-    if (accountIdDiv) {
-      const accountIdSpan = accountIdDiv.parentElement?.querySelector('div > span:last-of-type');
-
-    if (accountIdSpan) {
-      accountId = accountIdSpan.textContent?.replaceAll('-', '') || null;
-    }
-  }
-
-  const roleNameDiv = accountMenu.querySelector('div[title]');
-  const roleName = roleNameDiv?.getAttribute('title') || null;  
-  const ssoRole = roleName ? ssoRoleName(roleName) : null;
-
-  return { accountId, roleName, ssoRoleName: ssoRole };
+  userType: 'iam' | 'sso';
 }
+
+const parseAccountMenu = (accountMenu: HTMLElement, prompts: string[]): AccountMenuInfo => {
+  // scrape values from the aws console account menu (top right)
+  // some pages are using an older version of the menu
+  // the old menu prompt includes the ': ', new one does not
+  // old iam: 'Currently active as: '
+  // old sso: 'Account ID: '
+  // new iam: 'Currently active as'
+  // new sso: 'Account ID'
+  const oldAccountPrompt = accountMenu.firstElementChild?.getElementsByTagName('span')[0].textContent || '';
+  
+  if (oldAccountPrompt === 'Currently active as: ') {
+    return {
+      userType: 'iam',
+      accountId: accountMenu.lastElementChild!.getElementsByTagName('span')[1].textContent!.replaceAll('-', ''),
+      roleName: accountMenu.firstElementChild!.getElementsByTagName('span')[1].textContent!,
+      ssoRoleName: null
+    };
+  }
+  
+  if (oldAccountPrompt.replace(': ', '') && prompts.includes(oldAccountPrompt.replace(': ', ''))) {
+    const accountId = accountMenu.firstElementChild!.getElementsByTagName('span')[1].textContent!.replaceAll('-', '');
+    const roleName = accountMenu.lastElementChild!.getAttribute('title')!;
+    return {
+      userType: 'sso',
+      accountId,
+      roleName,
+      ssoRoleName: ssoRoleName(roleName)
+    };
+  }
+  
+  const allDivs = Array.from(accountMenu.querySelectorAll('div'));
+  const accountIdDiv = allDivs.find(div => prompts.includes(div.textContent?.trim() ?? ''));
+  
+  if (accountIdDiv) {
+    const accountIdSpan = accountIdDiv.parentElement?.querySelector('div > span:last-of-type');
+    const accountId = accountIdSpan?.textContent?.replaceAll('-', '') || null;
+    const roleNameDiv = accountMenu.querySelector('div[title]');
+    const roleName = roleNameDiv?.getAttribute('title') || null;
+    
+    return {
+      userType: 'sso',
+      accountId,
+      roleName,
+      ssoRoleName: roleName ? ssoRoleName(roleName) : null
+    };
+  }
+  
+  return {
+    userType: 'iam',
+    accountId: accountMenu.getElementsByTagName('span')[7].textContent!.replaceAll('-', ''),
+    roleName: accountMenu.getElementsByTagName('span')[3].textContent!,
+    ssoRoleName: null
+  };
+};
 
 async function init(): Promise<AwsConsole> {
   const aws: AwsConsole = {
@@ -253,38 +280,17 @@ async function init(): Promise<AwsConsole> {
     appProfile: null,
     iamRole: null,
   };
-  // scrape values from the aws console account menu (top right)
-  // some pages are using an older version of the menu
-  // the old menu prompt includes the ': ', new one does not
-  // old iam: 'Currently active as: '
-  // old sso: 'Account ID: '
-  // new iam: 'Currently active as'
-  // new sso: 'Account ID'
+
   const accountMenu = await getAccountMenu();
-  const oldAccountPrompt = accountMenu!.firstElementChild!.getElementsByTagName('span')[0].textContent || '';
-  if (oldAccountPrompt === 'Currently active as: ') {
-    aws.userType = 'iam';
-    aws.accountId = accountMenu!.lastElementChild!.getElementsByTagName('span')[1].textContent!.replaceAll('-', '');
-    aws.roleName = accountMenu!.firstElementChild!.getElementsByTagName('span')[1].textContent!;
-  } else if (ssoAccountPrompts.includes(oldAccountPrompt!.replace(': ', ''))) {
-    aws.userType = 'sso';
-    aws.accountId = accountMenu!.firstElementChild!.getElementsByTagName('span')[1].textContent!.replaceAll('-', '');
-    aws.roleName = accountMenu!.lastElementChild!.getAttribute('title')!;
-    aws.ssoRoleName = ssoRoleName(aws.roleName);
-  } else if (accountMenuHasOneOfAccountPrompts(accountMenu, ssoAccountPrompts)) {
-    extension.log('sso user');
-    aws.userType = 'sso';
-    Object.assign(aws, parseSsoMenu(accountMenu, ssoAccountPrompts));
-  } else {
-    extension.log('iam user');
-    aws.userType = 'iam';
-    aws.accountId = accountMenu.getElementsByTagName('span')[7].textContent!.replaceAll('-', '');
-    aws.roleName = accountMenu.getElementsByTagName('span')[3].textContent!
-  }
+  const menuInfo = parseAccountMenu(accountMenu, ssoAccountPrompts);
+  
+  Object.assign(aws, menuInfo);
+
   if ((aws.userType === 'sso' && aws.ssoRoleName)
     || (aws.userType === 'iam' && aws.roleName)) {
     aws.data = await extension.loadData();
   }
+
   if (aws.data) { aws.user = extension.findUser(aws.data); }
   if (aws.user && aws.userType === 'sso') {
     aws.iamRole = null;

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -74,7 +74,7 @@ class Extension {
   constructor(config: ExtensionConfig) {
     this.config = config;
     this.platform = this.checkPlatform();
-    this.consoleUrlRegex = /^https:\/\/(((?<region>\w{2}-\w+-\d{1,2})|support|s3|health)\.console\.aws\.amazon|console\.amazonaws-us-gov)\.com\/(?<path>.*)?$/;
+    this.consoleUrlRegex = /^https:\/\/((((?<random>[0-9A-Za-z-]+)\.)?((?<region>\w{2}-\w+-\d{1,2})|support|s3|health)\.console\.aws\.amazon)|console\.amazonaws-us-gov)\.com\/(?<path>.*)?$/;
     this.ssoUrl = '';
     this.loaded = false;
     this.apps = [];

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -332,8 +332,11 @@ class Extension {
 
     const currentTab = (await this.config.browser.tabs.query({currentWindow: true, active: true}))[0];
     // if the current tab in the console, specify the destination
-    if (currentTab.url?.match(this.consoleUrlRegex)) {
-      consoleUrl = `${consoleUrl}&destination=${encodeURIComponent(currentTab.url)}`;
+
+    const matches = currentTab.url?.match(this.consoleUrlRegex);
+    if (matches && currentTab.url) {
+      const currentTabUrl = matches.groups?.random ? currentTab.url.replace(`${matches.groups?.random}.`, '') : currentTab.url;
+      consoleUrl = `${consoleUrl}&destination=${encodeURIComponent(currentTabUrl)}`;
     }
 
     return consoleUrl;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -19,26 +19,19 @@ function waitForElement<TElement extends Element = HTMLElement>(
       return;
     }
 
-    const observer = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        Array.from(mutation.addedNodes).forEach((addedNode) => {
-          if (addedNode.nodeType === Node.ELEMENT_NODE) {
-            const targetElement = (addedNode as Element).querySelector<TElement>(selector);
-
-            if (targetElement) {
-              observer.disconnect();
-              resolve(targetElement);
-            }
-          }
-        });
-      });
+    const observer = new MutationObserver(() => {
+      const element = document.querySelector<TElement>(selector);
+      if (element) {
+        observer.disconnect();
+        resolve(element);
+      }
     });
 
     observer.observe(document.documentElement, { childList: true, subtree: true });
 
     setTimeout(() => {
       observer.disconnect();
-      reject(new Error(`Timeout: Element not found with selector "${selector}"`));
+      reject(new Error(`Timeout: Element not found with selector "${selector}" after ${timeout}ms`));
     }, timeout);
   });
 }


### PR DESCRIPTION
Fixes https://github.com/WTFender/aws-sso-extender/issues/177 

- **feat(multi-session): adapt console regex to match mutlti-session sub domains**
- **fix(utils): waitForElement is more simple and manage more cases**
- **feat(multi-session): remove subdomain if any in createProfileUrl to avoid a 404**
- **feat(multi-session): grab information from sso menu both with classic and multi session modes**
