### PR TITLE
fix: increase timeout for slower page load

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,7 +9,7 @@ function waitForElement<TElement extends Element = HTMLElement>(
   } = {},
 ): Promise<TElement> {
   extension.log(`waitForElement:${selector}`);
-  const { timeout = 3000, parentNode = document } = options;
+  const { timeout = 20_000, parentNode = document } = options;
 
   return new Promise((resolve, reject) => {
     const element = parentNode.querySelector<TElement>(selector);


### PR DESCRIPTION
Hello!

First of all, thanks for the extension! 

I occasionally encounter timeouts because the page takes longer than 3 seconds to load. To address this, I’ve increased the timeout and added local logs to measure how many milliseconds it takes for the menu to be added to the DOM.

On average, the load time is around 6-7 seconds, but I’ve set the timeout to 20 seconds to account for low-bandwidth connections.

Are there any potential blockers with increasing the timeout?

(I've tried with Chrome without any extension except this one)