### PR TITLE
Release 1.9.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,12 +36,12 @@ jobs:
       - name: Build Firefox Extension
         run: npm run build:firefox
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: aws_sso_extender-${{ steps.setup.outputs.version }}-chrome.zip
           path: ./release/chrome/aws_sso_extender-${{ steps.setup.outputs.version }}.zip
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: aws_sso_extender-${{ steps.setup.outputs.version }}-firefox.zip
           path: ./release/firefox/aws_sso_extender-${{ steps.setup.outputs.version }}.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.9.5
+ - Added support for using local storage as   an alternative to sync storage. This helps prevent failures caused by sync storage quota limits when managing many profiles (fixes #172).
+
 ## 1.9.4
 - Switching profiles will now retain the focused profile's region & page (thanks @j-smz)
 - Fixed console labels not displaying due to AWS console changes (thanks @chrisgilbert)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "WTFender",
   "url": "https://github.com/WTFender/aws-sso-extender",
   "private": true,
-  "version": "1.9.4",
+  "version": "1.9.5",
   "type": "module",
   "scripts": {
     "prepare": "husky install",

--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -257,6 +257,7 @@ const demoData: ExtensionData = {
   appProfiles,
   iamLogins: [],
   settings: {
+    lastUpdated: Date.now(),
     defaultUser: 'lastUserId',
     enableSync: false,
     copyLinkButton: true,

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -51,7 +51,9 @@ class Extension {
 
   defaultSettings = {
     defaultUser: 'lastUserId',
-    enableSync: true,
+    lastUpdated: Date.now(),
+    copyLinkButton: true, 
+    enableSync: false,
     lastUserId: null,
     lastProfileId: null,
     firefoxContainers: false,
@@ -244,7 +246,7 @@ class Extension {
     const users: Array<Promise<UserData>> = [];
     const usersKey = `${this.config.name}-users`;
     // keep users list in sync
-    const usersData = await this.config.browser.storage.sync.get(usersKey);
+    const usersData = enableSync ? await this.config.browser.storage.sync.get(usersKey) : await this.config.browser.storage.local.get(usersKey);
     const userIds = usersData[usersKey] === undefined
       ? []
       : JSON.parse(usersData[usersKey]).users;
@@ -258,31 +260,66 @@ class Extension {
   }
 
   async saveSettings(settings: ExtensionSettings): Promise<void> {
+    settings.lastUpdated = Date.now()
     await this.saveData(
       `${this.config.name}-settings`,
       settings,
-      this.config.browser.storage.sync,
+      settings.enableSync ? this.config.browser.storage.sync : this.config.browser.storage.local,
     );
   }
 
   async loadSettings(): Promise<ExtensionSettings> {
     this.log('loadSettings');
     const setKey = `${this.config.name}-settings`;
-    const setData = await this.config.browser.storage.sync.get(setKey);
-    // eslint-disable-next-line vue/max-len
-    const settings = setData[setKey] === undefined
-      ? this.defaultSettings
-      : JSON.parse(setData[setKey]);
-    // replace missing settings with default settings
+    const dataSyncStorage = (await this.config.browser.storage.sync.get(setKey))[setKey] as string | undefined;
+    const dataLocalStorage = (await this.config.browser.storage.local.get(setKey))[setKey] as string | undefined;
+    const localParsed = dataLocalStorage === undefined? undefined : JSON.parse(dataLocalStorage)
+    const syncParsed = dataSyncStorage === undefined? undefined : JSON.parse(dataSyncStorage)
+    const settings  = this.selectSettingsFromStorageProvider(syncParsed, localParsed)
+    return settings
+  }
+
+  selectSettingsFromStorageProvider(syncProviderData:any , localProviderData:any ): ExtensionSettings{
+    const local = this.fillMissingSettings(localProviderData)
+    const sync = this.fillMissingSettings(syncProviderData)   
+
+    let settings:any 
+    if (local === undefined && sync === undefined) {
+      settings  = this.defaultSettings 
+    }
+    if (local === undefined && sync !== undefined )
+      settings =  sync
+
+    if (local !== undefined && sync === undefined )
+      settings =  local
+    
+    // Checking which storage type that was last updated, and choose it as the storage provider
+    this.log(local)
+    this.log(sync)
+    if (!settings)
+      if (local.lastUpdated > sync.lastUpdated)
+          settings =  local
+      else 
+          settings = sync
+    
+    return settings as ExtensionSettings
+
+  }
+
+  fillMissingSettings(settings:any){
+     // replace missing settings with default settings
     // useful when adding new settings between versions
+    if (settings === undefined)
+      return settings
     Object.keys(this.defaultSettings).forEach((key) => {
       // no key or undefined
       if (!Object.prototype.hasOwnProperty.call(settings, key)) {
         settings[key] = this.defaultSettings[key];
       }
     });
-    return settings as ExtensionSettings;
+    return settings
   }
+
 
   getDefaultUser(data: ExtensionData): UserData {
     this.log('getDefaultUser');
@@ -525,7 +562,7 @@ class Extension {
       this.saveData(
         `${this.config.name}-users`,
         { users: [...new Set(userIds)] },
-        this.config.browser.storage.sync,
+        data.settings.enableSync ? this.config.browser.storage.sync : this.config.browser.storage.local,
       );
       this.saveAppProfiles(user, data.settings.enableSync);
     });

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -20,6 +20,7 @@ export interface ExtensionConfig {
 }
 
 export interface ExtensionSettings {
+  lastUpdated: number;
   copyLinkButton: boolean;
   defaultUser: string;
   enableSync: boolean;
@@ -27,8 +28,8 @@ export interface ExtensionSettings {
   firefoxResumeContainer: boolean;
   firefoxExpireMinsContainer: number;
   iconColor: string;
-  lastUserId: string;
-  lastProfileId: string;
+  lastUserId: string | null;
+  lastProfileId: string | null;
   navCurrentTab: boolean;
   showReleaseNotes: boolean;
   showAllProfiles: boolean;

--- a/src/views/options.vue
+++ b/src/views/options.vue
@@ -577,7 +577,7 @@ export default {
         { label: 'Only Use Current Tab', id: 'navCurrentTab', tooltip: 'Only use the current tab when navigating to profiles and URLs.'},
         { label: 'Show All Profiles on Open', id: 'showAllProfiles', tooltip: 'Show all profiles when opening the extension popup, instead of filtering to favorites (default: false)' },
         { label: 'Show Release Notes on Update', id: 'showReleaseNotes', tooltip: 'When the extension is updated, open a browser tab with a link to the release notes (default: true)' },
-        { label: 'Sync User Settings', id: 'enableSync', tooltip: 'Sync user settings across browsers. (default: true)' },
+        { label: 'Sync User Settings', id: 'enableSync', tooltip: 'Sync user settings across browsers. (default: false), with large number of SSO roles syncing set to true might exceed the sync storage api rendering the extension unusable ' },
       ],
       resources: [
         {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,6 +44,7 @@ export default defineConfig(async ({ mode }) => {
         browser: platform,
         manifest: action === 'watch' ? generateManifestDevtools : generateManifest,
         watchFilePaths: ['package.json', 'manifest.json'],
+        skipManifestValidation: true,
       }),
     ],
   };


### PR DESCRIPTION
## 1.9.5
 - Added support for using local storage as   an alternative to sync storage. This helps prevent failures caused by sync storage quota limits when managing many profiles (fixes #172 #184).