### PR TITLE
Add multi-session support for Copy Link feature

### DIFF
--- a/src/entry/aws-console.ts
+++ b/src/entry/aws-console.ts
@@ -107,19 +107,8 @@ function checkIamLogins(aws: AwsConsole) {
   }
 }
 
-async function getMenu() {
-  // In both multi-session and non-multi-session modes, the menu element
-  // exists in the DOM (though may be hidden). Use querySelector directly.
-  // Add small retry in case the DOM isn't quite ready yet.
-  for (let i = 0; i < 20; i++) {
-    const menu = document.querySelector('#menu--account');
-    if (menu) {
-      return menu;
-    }
-    // Wait a bit if not found yet (rare case)
-    await new Promise(resolve => setTimeout(resolve, 100));
-  }
-  throw new Error('Timeout: Element not found with selector "#menu--account"');
+function getMenu() {
+  return waitForElement('#menu--account');
 }
 function getHeader() {
   return waitForElement('#awsc-top-level-nav');

--- a/src/entry/aws-console.ts
+++ b/src/entry/aws-console.ts
@@ -107,8 +107,19 @@ function checkIamLogins(aws: AwsConsole) {
   }
 }
 
-function getMenu() {
-  return waitForElement('#menu--account');
+async function getMenu() {
+  // In both multi-session and non-multi-session modes, the menu element
+  // exists in the DOM (though may be hidden). Use querySelector directly.
+  // Add small retry in case the DOM isn't quite ready yet.
+  for (let i = 0; i < 20; i++) {
+    const menu = document.querySelector('#menu--account');
+    if (menu) {
+      return menu;
+    }
+    // Wait a bit if not found yet (rare case)
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+  throw new Error('Timeout: Element not found with selector "#menu--account"');
 }
 function getHeader() {
   return waitForElement('#awsc-top-level-nav');
@@ -189,15 +200,33 @@ function customizeConsole(aws: AwsConsole): void {
         // add the new node we made in the above loop to the nav bar
         if (copiedNode) menuList.append(copiedNode);
         // run the function below when the button is clicked
-        document.getElementById("copyLinkButton")?.addEventListener("click", () => copyToClipBoard(aws.user!.managedActiveDirectoryId,aws.accountId!,aws.ssoRoleName!))
+        document.getElementById("copyLinkButton")?.addEventListener("click", () => copyToClipBoard(aws))
       });
     });
   }
 }
 
 
-function copyToClipBoard(awsDirectoryId: string,accountId: string,ssoRoleName: string){
-  var linkurl="https://"+awsDirectoryId+".awsapps.com/start/#/console?account_id="+accountId+"&role_name="+ssoRoleName+"&destination="+encodeURIComponent(window.location.href);
+function getSsoSubdomain(user: UserData): string {
+  // Try to get SSO subdomain from user's custom settings first (for vanity URLs like acme.awsapps.com)
+  if (user.custom?.ssoSubdomain) {
+    return user.custom.ssoSubdomain;
+  }
+  // Fall back to managed directory ID (like d-123abc1234)
+  return user.managedActiveDirectoryId;
+}
+
+function copyToClipBoard(aws: AwsConsole){
+  let linkurl: string;
+
+  // Strip multi-session subdomain from destination URL
+  // Convert: https://123456789012-abc123xy.us-east-1.console.aws.amazon.com/...
+  // To: https://us-east-1.console.aws.amazon.com/...
+  const cleanDestinationUrl = window.location.href.replace(/https:\/\/\d{12}-[a-z0-9]+\./, 'https://');
+
+  const ssoSubdomain = getSsoSubdomain(aws.user!);
+  linkurl = `https://${ssoSubdomain}.awsapps.com/start/#/console?account_id=${aws.accountId}&role_name=${aws.ssoRoleName}&destination=${encodeURIComponent(cleanDestinationUrl)}`;
+
   navigator.clipboard.writeText(linkurl);
   waitForElement('#copyLinkButton').then(async (el)=> { var textElement=el.querySelector("span"); if (textElement){textElement.textContent="Link Copied"; await delay(1000); textElement.textContent="Copy Link"}})
 }
@@ -217,40 +246,92 @@ async function init(): Promise<AwsConsole> {
     appProfile: null,
     iamRole: null,
   };
-  // scrape values from the aws console account menu (top right)
-  // some pages are using an older version of the menu
-  // the old menu prompt includes the ': ', new one does not
-  // old iam: 'Currently active as: '
-  // old sso: 'Account ID: '
-  // new iam: 'Currently active as'
-  // new sso: 'Account ID'
-  const menu = await getMenu();
-  const accountMenu = menu.firstElementChild!.firstElementChild!;
-  const oldAccountPrompt = accountMenu.firstElementChild!.getElementsByTagName('span')[0].textContent || '';
-  let accountPrompt = '';
-  if (oldAccountPrompt === '') {
-    accountPrompt = accountMenu!.firstElementChild!.firstElementChild!.firstElementChild!.firstElementChild!.textContent!;
-  }
-  if (oldAccountPrompt === 'Currently active as: ') {
-    aws.userType = 'iam';
-    aws.accountId = accountMenu!.lastElementChild!.getElementsByTagName('span')[1].textContent!.replaceAll('-', '');
-    aws.roleName = accountMenu!.firstElementChild!.getElementsByTagName('span')[1].textContent!;
-  } else if (ssoAccountPrompts.includes(oldAccountPrompt!.replace(': ', ''))) {
-    aws.userType = 'sso';
-    aws.accountId = accountMenu!.firstElementChild!.getElementsByTagName('span')[1].textContent!.replaceAll('-', '');
-    aws.roleName = accountMenu!.lastElementChild!.getAttribute('title')!;
-    aws.ssoRoleName = ssoRoleName(aws.roleName);
-  } else if (ssoAccountPrompts.includes(accountPrompt)) {
-    extension.log('sso user');
-    aws.userType = 'sso';
-    aws.accountId = accountMenu!.firstElementChild!.getElementsByTagName('span')[3].textContent!.replaceAll('-', '');
-    aws.roleName = accountMenu!.firstElementChild!.lastElementChild?.firstElementChild!.getAttribute('title')!;
-    aws.ssoRoleName = ssoRoleName(aws.roleName);
+
+  // Detect if multi-session mode is enabled by checking URL format
+  // Multi-session: https://123456789012-abc123xy.us-east-1.console.aws.amazon.com/...
+  // Non-multi-session: https://us-east-1.console.aws.amazon.com/...
+  const isMultiSession = /^https:\/\/\d{12}-[a-z0-9]+\./.test(window.location.href);
+  extension.log(`Multi-session mode: ${isMultiSession}`);
+
+  if (isMultiSession) {
+    // Multi-session mode: Parse from button attributes (title has complete info)
+    // Wait for the button and its title to be populated (it gets set dynamically)
+    let menuButton: Element | null = null;
+    let title = '';
+
+    // Poll for title to be populated - usually takes 600-800ms
+    for (let i = 0; i < 30; i++) {
+      menuButton = document.querySelector('button[aria-controls="menu--account"]');
+      title = menuButton?.getAttribute('title') || '';
+      if (title) {
+        extension.log(`Title found after ${i + 1} attempts`);
+        break;
+      }
+      await new Promise(resolve => setTimeout(resolve, 200));
+    }
+
+    extension.log(`Button title: ${title}`);
+
+    // Check for "Federated user" label to detect SSO
+    const menu = await getMenu();
+    const allElements = Array.from(menu.querySelectorAll('*'));
+    const hasFederatedUser = allElements.some(el => el.textContent?.trim() === 'Federated user');
+
+    if (hasFederatedUser) {
+      extension.log('sso user (multi-session)');
+      aws.userType = 'sso';
+    } else {
+      extension.log('iam user (multi-session)');
+      aws.userType = 'iam';
+    }
+
+    // Extract account ID from title
+    const accountMatch = title.match(/@\s*([\d-]+)$/);
+    if (accountMatch) {
+      aws.accountId = accountMatch[1].replaceAll('-', '');
+      extension.log(`Account ID: ${aws.accountId}`);
+    }
+
+    // Extract role name from title
+    const roleMatch = title.match(/^([^/]+)/);
+    if (roleMatch) {
+      aws.roleName = roleMatch[1].trim();
+      extension.log(`Role name: ${aws.roleName}`);
+      if (aws.userType === 'sso') {
+        aws.ssoRoleName = ssoRoleName(aws.roleName);
+        extension.log(`SSO role name: ${aws.ssoRoleName}`);
+      }
+    }
   } else {
-    extension.log('iam user');
-    aws.userType = 'iam';
-    aws.accountId = accountMenu.getElementsByTagName('span')[7].textContent!.replaceAll('-', '');
-    aws.roleName = accountMenu.getElementsByTagName('span')[3].textContent!
+    // Non-multi-session mode: Use original DOM scraping logic
+    const menu = await getMenu();
+    const accountMenu = menu.firstElementChild!.firstElementChild!;
+    const oldAccountPrompt = accountMenu.firstElementChild!.getElementsByTagName('span')[0].textContent || '';
+    let accountPrompt = '';
+    if (oldAccountPrompt === '') {
+      accountPrompt = accountMenu!.firstElementChild!.firstElementChild!.firstElementChild!.firstElementChild!.textContent!;
+    }
+    if (oldAccountPrompt === 'Currently active as: ') {
+      aws.userType = 'iam';
+      aws.accountId = accountMenu!.lastElementChild!.getElementsByTagName('span')[1].textContent!.replaceAll('-', '');
+      aws.roleName = accountMenu!.firstElementChild!.getElementsByTagName('span')[1].textContent!;
+    } else if (ssoAccountPrompts.includes(oldAccountPrompt!.replace(': ', ''))) {
+      aws.userType = 'sso';
+      aws.accountId = accountMenu!.firstElementChild!.getElementsByTagName('span')[1].textContent!.replaceAll('-', '');
+      aws.roleName = accountMenu!.lastElementChild!.getAttribute('title')!;
+      aws.ssoRoleName = ssoRoleName(aws.roleName);
+    } else if (ssoAccountPrompts.includes(accountPrompt)) {
+      extension.log('sso user');
+      aws.userType = 'sso';
+      aws.accountId = accountMenu!.firstElementChild!.getElementsByTagName('span')[3].textContent!.replaceAll('-', '');
+      aws.roleName = accountMenu!.firstElementChild!.lastElementChild?.firstElementChild!.getAttribute('title')!;
+      aws.ssoRoleName = ssoRoleName(aws.roleName);
+    } else {
+      extension.log('iam user');
+      aws.userType = 'iam';
+      aws.accountId = accountMenu.getElementsByTagName('span')[7].textContent!.replaceAll('-', '');
+      aws.roleName = accountMenu.getElementsByTagName('span')[3].textContent!
+    }
   }
   if ((aws.userType === 'sso' && aws.ssoRoleName)
     || (aws.userType === 'iam' && aws.roleName)) {

--- a/src/entry/aws-console.ts
+++ b/src/entry/aws-console.ts
@@ -272,17 +272,23 @@ async function init(): Promise<AwsConsole> {
 
     extension.log(`Button title: ${title}`);
 
-    // Check for "Federated user" label to detect SSO
-    const menu = await getMenu();
-    const allElements = Array.from(menu.querySelectorAll('*'));
-    const hasFederatedUser = allElements.some(el => el.textContent?.trim() === 'Federated user');
+    // Extract role name from title
+    const roleMatch = title.match(/^([^/]+)/);
+    if (roleMatch) {
+      aws.roleName = roleMatch[1].trim();
+      extension.log(`Role name: ${aws.roleName}`);
 
-    if (hasFederatedUser) {
-      extension.log('sso user (multi-session)');
-      aws.userType = 'sso';
-    } else {
-      extension.log('iam user (multi-session)');
-      aws.userType = 'iam';
+      // Detect SSO vs IAM from role name pattern
+      // AWS IAM Identity Center always creates roles with AWSReservedSSO_ prefix
+      if (aws.roleName.startsWith('AWSReservedSSO_')) {
+        extension.log('sso user (multi-session)');
+        aws.userType = 'sso';
+        aws.ssoRoleName = ssoRoleName(aws.roleName);
+        extension.log(`SSO role name: ${aws.ssoRoleName}`);
+      } else {
+        extension.log('iam user (multi-session)');
+        aws.userType = 'iam';
+      }
     }
 
     // Extract account ID from title
@@ -290,17 +296,6 @@ async function init(): Promise<AwsConsole> {
     if (accountMatch) {
       aws.accountId = accountMatch[1].replaceAll('-', '');
       extension.log(`Account ID: ${aws.accountId}`);
-    }
-
-    // Extract role name from title
-    const roleMatch = title.match(/^([^/]+)/);
-    if (roleMatch) {
-      aws.roleName = roleMatch[1].trim();
-      extension.log(`Role name: ${aws.roleName}`);
-      if (aws.userType === 'sso') {
-        aws.ssoRoleName = ssoRoleName(aws.roleName);
-        extension.log(`SSO role name: ${aws.ssoRoleName}`);
-      }
     }
   } else {
     // Non-multi-session mode: Use original DOM scraping logic

--- a/src/entry/aws-console.ts
+++ b/src/entry/aws-console.ts
@@ -197,20 +197,16 @@ function customizeConsole(aws: AwsConsole): void {
 
 
 function getSsoSubdomain(user: UserData): string {
-  // Try to get SSO subdomain from user's custom settings first (for vanity URLs like acme.awsapps.com)
   if (user.custom?.ssoSubdomain) {
     return user.custom.ssoSubdomain;
   }
-  // Fall back to managed directory ID (like d-123abc1234)
   return user.managedActiveDirectoryId;
 }
 
 function copyToClipBoard(aws: AwsConsole){
   let linkurl: string;
 
-  // Strip multi-session subdomain from destination URL
-  // Convert: https://123456789012-abc123xy.us-east-1.console.aws.amazon.com/...
-  // To: https://us-east-1.console.aws.amazon.com/...
+  // Strip multi-session subdomain for shareable URL
   const cleanDestinationUrl = window.location.href.replace(/https:\/\/\d{12}-[a-z0-9]+\./, 'https://');
 
   const ssoSubdomain = getSsoSubdomain(aws.user!);
@@ -236,19 +232,12 @@ async function init(): Promise<AwsConsole> {
     iamRole: null,
   };
 
-  // Detect if multi-session mode is enabled by checking URL format
-  // Multi-session: https://123456789012-abc123xy.us-east-1.console.aws.amazon.com/...
-  // Non-multi-session: https://us-east-1.console.aws.amazon.com/...
   const isMultiSession = /^https:\/\/\d{12}-[a-z0-9]+\./.test(window.location.href);
   extension.log(`Multi-session mode: ${isMultiSession}`);
 
   if (isMultiSession) {
-    // Multi-session mode: Parse from button attributes (title has complete info)
-    // Wait for the button and its title to be populated (it gets set dynamically)
     let menuButton: Element | null = null;
     let title = '';
-
-    // Poll for title to be populated - usually takes 600-800ms
     for (let i = 0; i < 30; i++) {
       menuButton = document.querySelector('button[aria-controls="menu--account"]');
       title = menuButton?.getAttribute('title') || '';
@@ -261,14 +250,11 @@ async function init(): Promise<AwsConsole> {
 
     extension.log(`Button title: ${title}`);
 
-    // Extract role name from title
     const roleMatch = title.match(/^([^/]+)/);
     if (roleMatch) {
       aws.roleName = roleMatch[1].trim();
       extension.log(`Role name: ${aws.roleName}`);
 
-      // Detect SSO vs IAM from role name pattern
-      // AWS IAM Identity Center always creates roles with AWSReservedSSO_ prefix
       if (aws.roleName.startsWith('AWSReservedSSO_')) {
         extension.log('sso user (multi-session)');
         aws.userType = 'sso';
@@ -279,15 +265,12 @@ async function init(): Promise<AwsConsole> {
         aws.userType = 'iam';
       }
     }
-
-    // Extract account ID from title
     const accountMatch = title.match(/@\s*([\d-]+)$/);
     if (accountMatch) {
       aws.accountId = accountMatch[1].replaceAll('-', '');
       extension.log(`Account ID: ${aws.accountId}`);
     }
   } else {
-    // Non-multi-session mode: Use original DOM scraping logic
     const menu = await getMenu();
     const accountMenu = menu.firstElementChild!.firstElementChild!;
     const oldAccountPrompt = accountMenu.firstElementChild!.getElementsByTagName('span')[0].textContent || '';

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -76,7 +76,10 @@ class Extension {
   constructor(config: ExtensionConfig) {
     this.config = config;
     this.platform = this.checkPlatform();
-    this.consoleUrlRegex = /^https:\/\/(((?<region>\w{2}-\w+-\d{1,2})|support|s3|health)\.console\.aws\.amazon|console\.amazonaws-us-gov)\.com\/(?<path>.*)?$/;
+    // Updated regex to handle both standard and multi-session URLs
+    // Standard: https://us-east-1.console.aws.amazon.com/...
+    // Multi-session: https://412381741422-hh323s3c.us-east-1.console.aws.amazon.com/...
+    this.consoleUrlRegex = /^https:\/\/(\d{12}-[a-z0-9]+\.)?(((?<region>\w{2}-\w+-\d{1,2})|support|s3|health)\.console\.aws\.amazon|console\.amazonaws-us-gov)\.com\/(?<path>.*)?$/;
     this.ssoUrl = '';
     this.loaded = false;
     this.apps = [];

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -83,6 +83,7 @@ export interface UserData {
     labelHeader: boolean,
     labelIcon: boolean,
     profiles: Record<string, CustomData>
+    ssoSubdomain?: string,
     hotkeys: {
       openProfile1: string,
       openProfile2: string,

--- a/src/views/options.vue
+++ b/src/views/options.vue
@@ -246,6 +246,23 @@
                 @change="saveUser()"
               />
             </div>
+            <div>
+              <small
+                id="sso-subdomain-label"
+                class="option-label"
+              >SSO Subdomain (optional)</small>
+              <br>
+              <InputText
+                id="ssoSubdomain"
+                v-model="user.custom.ssoSubdomain"
+                aria-describedby="sso-subdomain-label"
+                name="ssoSubdomain"
+                class="option-value"
+                style="width: 330px; margin-right: 10px; margin-bottom: 5px;"
+                placeholder="e.g., yourcompany (for yourcompany.awsapps.com)"
+                @change="saveUser()"
+              />
+            </div>
             <div
               class="option-label"
               style="margin-left: 1rem;"


### PR DESCRIPTION
Fixes the Copy Link button not appearing when AWS multi-session support is enabled.

**Problem:** When AWS multi-session support is enabled, the console URL format changes from https://us-east-1.console.aws.amazon.com/... to https://123456789012-abc123xy.us-east-1.console.aws.amazon.com/...

### This caused two issues:
1. The extension's consoleUrlRegex didn't match multi-session URLs
2. The Copy Link button didn't appear in multi-session mode

### Changes:
- **Updated consoleUrlRegex** to match multi-session URLs
- **Added multi-session detection** in init() based on URL pattern
- **Parse account/role from button title** attribute in multi-session mode (avoids DOM scraping)
- **Detect SSO vs IAM** from AWSReservedSSO_ role prefix (AWS IAM Identity Center standard)
- **Enhanced copyToClipBoard()** to strip multi-session subdomain for shareability
- **Added ssoSubdomain field** for custom SSO domains (e.g., company.awsapps.com)
- **Added UI field** in options page for SSO subdomain configuration

Tested in both multi-session and non-multi-session modes.