### PR TITLE
Fix user cycling and save loop

### DIFF
--- a/src/entry/background.ts
+++ b/src/entry/background.ts
@@ -10,17 +10,19 @@ extension.loadData().then((data: ExtensionData) => {
   });
 
   // listen for hotkey commands
-  extension.config.browser.commands.onCommand.addListener((command) => {
+  extension.config.browser.commands.onCommand.addListener(async (command) => {
     extension.log(`background:command:${command}`);
     // message popup to open profile
     if (command.startsWith('openProfile')) {
-      extension.log(data);
-      const user = extension.findUser(data);
-      const appProfileId = user.custom.hotkeys[command];
+      // load fresh data at command time to avoid stale state
+      const latest: ExtensionData = await extension.loadData();
+      extension.log(latest);
+      const activeUser = extension.findUser(latest);
+      const appProfileId = activeUser.custom.hotkeys[command];
       extension.log(`background:command:appProfileId:${appProfileId}`);
       const appProfiles = extension.customizeProfiles(
-        data.users[0],
-        data.appProfiles,
+        activeUser,
+        latest.appProfiles,
       );
       const appProfile = extension.findAppProfileById(
         appProfileId,
@@ -29,9 +31,9 @@ extension.loadData().then((data: ExtensionData) => {
       extension.log(appProfile);
       extension.navSelectedProfile(
         appProfile,
-        data.users[0],
-        data.users,
-        data.settings,
+        activeUser,
+        latest.users,
+        latest.settings,
       );
     }
   });

--- a/src/views/options.vue
+++ b/src/views/options.vue
@@ -629,6 +629,7 @@ export default {
       loaded: false,
       loadedUser: false,
       loadedSettings: false,
+      isSaving: false,
     };
   },
   computed: {
@@ -715,7 +716,7 @@ export default {
       handler() {
         if (!this.loadedSettings) {
           this.loadedSettings = true;
-        } else if (!this.demoMode) {
+        } else if (!this.demoMode && !this.isSaving) {
           this.jsonEditor = {
             user: this.user.custom,
             extension: this.settings,
@@ -771,9 +772,11 @@ export default {
   methods: {
     nextUser() {
       this.switchUser = true;
-      const options = this.userOptions;
-      const currentUserIdx = options.findIndex((u) => u.userId === this.user.userId);
-      this.user = options[currentUserIdx + 1] || options[0];
+      // iterate using stable users list to avoid reordering from userOptions
+      const idx = this.users.findIndex((u) => u.userId === this.user.userId);
+      const nextIdx = (idx === -1 ? 0 : (idx + 1) % this.users.length);
+      // eslint-disable-next-line prefer-destructuring
+      this.user = this.users[nextIdx];
     },
     getFontColor(hex) {
       return getFontColor(hex);
@@ -944,12 +947,19 @@ export default {
       if (this.loaded && !this.demoMode && !this.user.userId.startsWith('demoUser')) {
         clearTimeout(this.saveTimeoutId);
         this.saveTimeoutId = setTimeout(() => {
-          this.$ext.saveUser(this.user, this.settings.enableSync).then(() => {
-            this.settings.lastUserId = this.user.userId;
-            this.$ext.saveSettings(this.settings).then(() => {
+          this.isSaving = true;
+          this.$ext.saveUser(this.user, this.settings.enableSync)
+            .then(() => {
+              // update lastUserId once per save cycle; watcher ignores while isSaving
+              this.settings.lastUserId = this.user.userId;
+              return this.$ext.saveSettings(this.settings);
+            })
+            .then(() => {
               this.notify('Saved Config', 'success');
+            })
+            .finally(() => {
+              this.isSaving = false;
             });
-          });
         }, 2000);
       }
     },


### PR DESCRIPTION
This PR
- uses active user with fresh data for commands
- adds an isSaving guard to stop Options save loop
- iterate users stably in nextUser() (fixes #189)