### PR TITLE
fix: paginate appinstances & profiles to support 100+ accounts

### DIFF
--- a/src/entry/aws-sso.ts
+++ b/src/entry/aws-sso.ts
@@ -30,19 +30,48 @@ async function getUserData(): Promise<UserData> {
 }
 
 async function getApps(): Promise<AppData[]> {
-  await RateLimiter();
-  await Semaphore.acquire();
-  return (api('/instance/appinstances').then(
-    (data) => data.result,
-  ) as Promise<AppData[]>).finally(() => { Semaphore.release(); });
+  const apps: AppData[] = [];
+  let nextToken: string | undefined;
+
+  do {
+    await RateLimiter();
+    await Semaphore.acquire();
+
+    const path = nextToken
+      ? `/instance/appinstances?next_token=${encodeURIComponent(nextToken)}`
+      : '/instance/appinstances';
+
+    // eslint-disable-next-line no-await-in-loop
+    const data = await api(path).finally(() => { Semaphore.release(); });
+
+    apps.push(...(data.result as AppData[]));
+    nextToken = data.paginationToken;
+  } while (nextToken);
+
+  return apps;
 }
 
 async function getAppProfiles(app: AppData): Promise<ProfileData[]> {
-  await RateLimiter();
-  await Semaphore.acquire();
-  return (api(`/instance/appinstance/${app.id}/profiles`).then(
-    (data) => data.result,
-  ) as Promise<ProfileData[]>).finally(() => { Semaphore.release(); });
+  const profiles: ProfileData[] = [];
+  let nextToken: string | undefined;
+
+  do {
+    await RateLimiter();
+    await Semaphore.acquire();
+
+    const base = `/instance/appinstance/${app.id}/profiles`;
+    const path = nextToken
+      ? `${base}?next_token=${encodeURIComponent(nextToken)}`
+      : base;
+
+    // eslint-disable-next-line no-await-in-loop
+    const data = await api(path).finally(() => { Semaphore.release(); });
+
+    profiles.push(...(data.result as ProfileData[]));
+    nextToken = data.paginationToken;
+  } while (nextToken);
+
+  return profiles;
 }
 
 extension.log(window.location.href);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -66,6 +66,7 @@ export interface ExtensionMessage {
 
 export interface ApiData {
   result: AppData[] | ProfileData[]
+  paginationToken?: string
 }
 
 export interface UserData {


### PR DESCRIPTION
## Problem
On large AWS Identity Center tenants, not all SSO profiles are loaded.

Environment: 281 accounts × 2 permission sets = 562 profiles expected.
- Chrome: only ~284 profiles stored
- Edge: only ~196 profiles stored
- Unique account IDs retrieved: ~97 (stops near the API page limit)
- Count fluctuates between runs

## Root cause
`getApps()` and `getAppProfiles()` in `src/entry/aws-sso.ts` call the
SSO Portal API once and return `data.result`, ignoring `data.paginationToken`.
The API returns ~98 items per page, so tenants with >100 accounts are
silently truncated.

## Fix
Loop with `next_token` query parameter until `paginationToken` is absent
from the response, for both appinstances and profiles.

API behavior verified:
- Response pagination key: `paginationToken`
- Request query parameter: `next_token`
- `max_result` parameter is ignored by the API (not needed)

## Testing
- Built with `npm run build:chrome`, loaded unpacked in Edge.
- Verified all 562 profiles (281 unique account IDs) are now stored.
- Count is stable across repeated logins.

Related: #172 #164